### PR TITLE
Make output more log-like

### DIFF
--- a/lib/auditor_cli.js
+++ b/lib/auditor_cli.js
@@ -22,7 +22,11 @@ AuditorCli.prototype.run = function(auditorClass) {
   auditor.audit(function(results) {
     var report = new ReportClass(results);
 
-    console.log(util.inspect(report.process(), false, null));
+    var results = report.process();
+
+    for(var i = 0; i < results.length; i++) {
+      console.log(util.inspect(results[i], false, null));
+    };
   }, function() {
     console.log("Failed to load the page at " + url + ".");
   });

--- a/lib/auditor_cli.js
+++ b/lib/auditor_cli.js
@@ -22,11 +22,11 @@ AuditorCli.prototype.run = function(auditorClass) {
   auditor.audit(function(results) {
     var report = new ReportClass(results);
 
-    var results = report.process();
+    var reportResults = report.process();
 
-    for(var i = 0; i < results.length; i++) {
-      console.log(util.inspect(results[i], false, null));
-    };
+    for(var i = 0; i < reportResults.length; i++) {
+      console.log(util.inspect(reportResults[i], false, null));
+    }
   }, function() {
     console.log("Failed to load the page at " + url + ".");
   });

--- a/lib/report.js
+++ b/lib/report.js
@@ -9,22 +9,19 @@ Report.prototype.process = function () {
   var url = this.rawResults.url;
 
   for(var i = 0; i < this.rawResults.violations.length; i++) {
-    results.push(this._transformResult( this.rawResults.violations[i]));
+    results.push(this._transformResult(this.rawResults.violations[i], url));
   }
 
-  return { url: url, warnings: results };
+  return results;
 };
 
-Report.prototype._transformResult = function(violation) {
+Report.prototype._transformResult = function(violation, url) {
   var targets = violation.nodes.map(function(n) {
     return n.target;
   });
 
-  return {
-    description: violation.help,
-    impact: violation.impact,
-    targets: targets
-  };
+  return [url, violation.impact, violation.help].join(" | ") +
+    " | [\"" + targets.join("\", \"") + "\"]";
 };
 
 module.exports = Report;

--- a/spec/report_spec.js
+++ b/spec/report_spec.js
@@ -10,7 +10,7 @@ describe("Report", function() {
 
         var results = report.process();
 
-        expect(results).toEqual({ url: "http://example.com", warnings: [] });
+        expect(results).toEqual([])
       });
     });
 
@@ -18,13 +18,14 @@ describe("Report", function() {
       it("returns a flattened representation of the raw results", function() {
         var report = new Report(
             {
-              url: "http://example.com",
+              url: "http://example.com/",
               violations: [
               {
-                help: "lang",
+                help: "<html> element must have a valid lang attribute",
                 impact: "critical",
                 nodes: [
-                  { target: "" }
+                  { target: "html" },
+                  { target: "span > a" }
                 ]
               }
               ]
@@ -33,14 +34,9 @@ describe("Report", function() {
 
         var results = report.process();
 
-        expect(results).toEqual({
-          url: "http://example.com",
-          warnings: [{
-            description: "lang",
-            impact: "critical",
-            targets: [""]
-          }]
-        });
+        expect(results).toEqual([
+          "http://example.com/ | critical | <html> element must have a valid lang attribute | [\"html\", \"span > a\"]"
+        ]);
       });
     });
   });

--- a/spec/report_spec.js
+++ b/spec/report_spec.js
@@ -10,7 +10,7 @@ describe("Report", function() {
 
         var results = report.process();
 
-        expect(results).toEqual([])
+        expect(results).toEqual([]);
       });
     });
 

--- a/spec/support/mock_report.js
+++ b/spec/support/mock_report.js
@@ -5,7 +5,7 @@ function MockReport(data) {
 }
 
 MockReport.prototype.process = function() {
-  return "processed data";
+  return ["processed data"];
 };
 
 module.exports = MockReport;


### PR DESCRIPTION
- Based on feedback from developers, convert JSON to log format, one
  warning per line.
- This will make the output more human readable.
- We might want to introduce a flag to print json soon.