### PR TITLE
Do not show full url path in log message

### DIFF
--- a/lib/auditor_cli.js
+++ b/lib/auditor_cli.js
@@ -20,7 +20,7 @@ AuditorCli.prototype.run = function(auditorClass) {
   var ReportClass = this.ReportClass;
 
   auditor.audit(function(results) {
-    var report = new ReportClass(results);
+    var report = new ReportClass(results, url);
 
     var reportResults = report.process();
 

--- a/lib/report.js
+++ b/lib/report.js
@@ -1,12 +1,13 @@
 "use strict";
 
-function Report(rawResults) {
+function Report(rawResults, url) {
   this.rawResults = rawResults;
+  this.url = url;
 }
 
 Report.prototype.process = function () {
   var results = [];
-  var url = this.rawResults.url;
+  var url = this.url;
 
   for(var i = 0; i < this.rawResults.violations.length; i++) {
     results.push(this._transformResult(this.rawResults.violations[i], url));

--- a/spec/report_spec.js
+++ b/spec/report_spec.js
@@ -5,8 +5,9 @@ describe("Report", function() {
   describe("#process", function() {
     describe("Empty raw results", function() {
       it("returns an empty array", function() {
-        var emptyFixture = { url: "http://example.com", violations: [] };
-        var report = new Report(emptyFixture);
+        var url = "http://example.com";
+        var emptyFixture = { violations: [] };
+        var report = new Report(emptyFixture, url);
 
         var results = report.process();
 
@@ -18,7 +19,6 @@ describe("Report", function() {
       it("returns a flattened representation of the raw results", function() {
         var report = new Report(
             {
-              url: "http://example.com/",
               violations: [
               {
                 help: "<html> element must have a valid lang attribute",
@@ -29,7 +29,8 @@ describe("Report", function() {
                 ]
               }
               ]
-            }
+            },
+            "http://example.com/"
             );
 
         var results = report.process();


### PR DESCRIPTION
- When we run the cli on files, axe-core returns the full file path as
  url, which is noisy. Instead, use the argument that was passed in.
