### PR TITLE
Raise error on page load failure

### DIFF
--- a/lib/auditor.js
+++ b/lib/auditor.js
@@ -62,7 +62,6 @@ Auditor.prototype.audit = function(callback, errorHandler) {
       phInstance.exit();
     });
   }).catch(function (error) {
-    console.log(error);
     errorHandler(error);
     phInstance.exit();
   });

--- a/lib/auditor_cli.js
+++ b/lib/auditor_cli.js
@@ -28,7 +28,7 @@ AuditorCli.prototype.run = function(auditorClass) {
       console.log(util.inspect(reportResults[i], false, null));
     }
   }, function() {
-    console.log("Failed to load the page at " + url + ".");
+    throw new Error("Failed to load the page at " + url + ".");
   });
 };
 

--- a/spec/auditor_cli_spec.js
+++ b/spec/auditor_cli_spec.js
@@ -33,13 +33,14 @@ describe("AuditorCli", function() {
     });
 
     it("prints failure", function() {
-      spyOn(console, "log");
       var cli = new AuditorCli(["node", "some_script", "failure_url"]);
 
+      try {
       cli.run(MockAuditor);
-
-      expect(console.log).
-        toHaveBeenCalledWith("Failed to load the page at failure_url.");
+      } catch(error) {
+        expect(error.message).
+          toEqual("Failed to load the page at failure_url.");
+      }
     });
   });
 });


### PR DESCRIPTION
- Do not swallow failures to run phantomjs.
- Instead, propagate the error and allow the user to handle the exit
  code.