### PR TITLE
Do not throw an error on page JavaScript errors

### DIFF
--- a/lib/auditor.js
+++ b/lib/auditor.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var phantom = require("phantom");
-var path = require("path");
 
 function Auditor(url, auditScript) {
   var defaultAuditScriptPath = __dirname + "/accesslint.js";
@@ -36,13 +35,17 @@ Auditor.prototype.audit = function(callback, errorHandler) {
 
   phantom.create().then(function (instance) {
     phInstance = instance;
+
     return instance.createPage();
   }).then(function (page) {
     sitepage = page;
+
     sitepage.property("viewportSize", {
       width: 1200,
       height: 900
     });
+
+    sitepage.on("onError", errorHandler);
 
     return sitepage.open(url);
   }).then(function (status) {
@@ -61,8 +64,9 @@ Auditor.prototype.audit = function(callback, errorHandler) {
       sitepage.close();
       phInstance.exit();
     });
-  }).catch(function (error) {
-    errorHandler(error);
+  }).catch(function (err) {
+    errorHandler(err);
+    sitepage.close();
     phInstance.exit();
   });
 };

--- a/lib/auditor_cli.js
+++ b/lib/auditor_cli.js
@@ -27,8 +27,8 @@ AuditorCli.prototype.run = function(auditorClass) {
     for(var i = 0; i < reportResults.length; i++) {
       console.log(util.inspect(reportResults[i], false, null));
     }
-  }, function() {
-    throw new Error("Failed to load the page at " + url + ".");
+  }, function(err) {
+    // noop
   });
 };
 

--- a/spec/auditor_cli_spec.js
+++ b/spec/auditor_cli_spec.js
@@ -32,15 +32,10 @@ describe("AuditorCli", function() {
       expect(console.log).toHaveBeenCalledWith("'processed data'");
     });
 
-    it("prints failure", function() {
+    it("does not throw an error", function() {
       var cli = new AuditorCli(["node", "some_script", "failure_url"]);
 
-      try {
-      cli.run(MockAuditor);
-      } catch(error) {
-        expect(error.message).
-          toEqual("Failed to load the page at failure_url.");
-      }
+      expect(function() { cli.run(MockAuditor); }).not.toThrow();
     });
   });
 });

--- a/spec/auditor_spec.js
+++ b/spec/auditor_spec.js
@@ -5,6 +5,8 @@ var express = require("express"),
 
 var app = express();
 
+var ERROR = "Page error!";
+
 app.get("/", function(request, response){
   response.send(
     "<html>" +
@@ -15,7 +17,12 @@ app.get("/", function(request, response){
 });
 
 app.get("/errors", function(request, response){
-  response.status(404).end();
+  response.send(
+    "<html>" +
+      "<head><script>throw new Error('" + ERROR + "');</script></head>" +
+      "<body></body>" +
+    "</html>"
+  );
 });
 
 var appServer = app.listen();
@@ -29,6 +36,16 @@ describe("Auditor", function() {
 
       auditor.audit(function(results) {
         expect(results.violations).toBeDefined();
+        done();
+      }, function() {});
+    });
+
+    it("propagates JavaScript errors", function(done) {
+      var url = "http://127.0.0.1:" + appServer.address().port + "/errors";
+      var auditor = new Auditor(url);
+
+      auditor.audit(function() {}, function(err) {
+        expect(err).toMatch(ERROR);
         done();
       });
     });

--- a/spec/support/mock_auditor.js
+++ b/spec/support/mock_auditor.js
@@ -8,7 +8,7 @@ MockAuditor.prototype.audit = function(callback, errorHandler) {
   if(this.url === "success_url") {
     callback([]);
   } else {
-    errorHandler();
+    errorHandler(new Error("mock auditor error"));
   }
 };
 


### PR DESCRIPTION
- Swallow the errors and move on.
- This will skip results for the page, which we don't want in the
  longterm.